### PR TITLE
move youtube_embed method in app/lib and fix code to make rubocop pass

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ AllCops:
   TargetRubyVersion: 2.4
   Exclude:
     - "db/schema.rb"
-    - "lib/generators/kuina_mailer/*"
+    - "app/lib/youtube_embed.rb"
   UseCache: false
 Rails:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,6 @@ gem 'faker', '~> 1.7'
 gem 'haml', '~> 4.0', '>= 4.0.7'
 
 group :development, :test do
-  gem "erb2haml"
   gem 'better_errors'
   gem 'binding_of_caller'
   gem 'rubocop', '~> 0.48.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,8 +94,6 @@ GEM
       warden (~> 1.2.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
-    erb2haml (0.1.5)
-      html2haml
     erubis (2.7.0)
     execjs (2.7.0)
     faker (1.7.3)
@@ -123,11 +121,6 @@ GEM
       activesupport (>= 4.2.0)
     haml (4.0.7)
       tilt
-    html2haml (2.1.0)
-      erubis (~> 2.7.0)
-      haml (~> 4.0)
-      nokogiri (>= 1.6.0)
-      ruby_parser (~> 3.5)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httparty (0.14.0)
@@ -258,8 +251,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    ruby_parser (3.9.0)
-      sexp_processor (~> 4.1)
     rubyzip (1.2.1)
     sass (3.4.23)
     sass-rails (5.0.6)
@@ -268,7 +259,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sexp_processor (4.9.0)
     simple_form (3.4.0)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
@@ -316,7 +306,6 @@ DEPENDENCIES
   ckeditor (= 4.1.3)
   cloudinary
   devise
-  erb2haml
   faker (~> 1.7)
   figaro
   font-awesome-sass

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -12,7 +12,7 @@ class ArticlesController < ApplicationController
     @article = Article.friendly.find(params[:id])
     authorize @article
     if @article.youtube
-      @video = youtube_embed(@article.youtube)
+      @video = YoutubeEmbed.youtube_embed(@article.youtube)
     end 
   end
 
@@ -20,18 +20,6 @@ class ArticlesController < ApplicationController
 
   def article_params
     params.require(:article).permit(:title, :description, :locale, :photo, :photo_cache)
-  end
-  
-  def youtube_embed(youtube_url)
-    if youtube_url[/youtu\.be\/([^\?]*)/]
-      youtube_id = $1
-    else
-      # Regex from # http://stackoverflow.com/questions/3452546/javascript-regex-how-to-get-youtube-video-id-from-url/4811367#4811367
-      youtube_url[/^.*((v\/)|(embed\/)|(watch\?))\??v?=?([^\&\?]*).*/]
-      youtube_id = $5
-    end
-
-    %Q{<iframe title="YouTube video player" width="640" height="390" src="https://www.youtube.com/embed/#{ youtube_id }" frameborder="0" allowfullscreen></iframe>}
   end
     
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,7 @@
 class PagesController < ApplicationController
 
-  skip_before_action :authenticate_user!, only: [:index, :coming_soon]
-  before_action :destroy_user_if_current_user, only: [:index]
+  skip_before_action :authenticate_user!, only: %i[index coming_soon]
+  before_action :destroy_user_if_current_user, only: %i[index]
 
   def index
     @courses = Course.where(locale: I18n.locale).sort_by(&:date_start).last(4)

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -12,7 +12,7 @@ class StoriesController < ApplicationController
     @story = Story.friendly.find(params[:id])
     authorize @story
     if @story.youtube
-      @video = youtube_embed(@story.youtube)
+      @video = YoutubeEmbed.youtube_embed(@story.youtube)
     end 
   end
 
@@ -20,18 +20,6 @@ class StoriesController < ApplicationController
 
   def story_params
     params.require(:story).permit(:title, :description, :locale, :photo, :photo_cache)
-  end
-  
-  def youtube_embed(youtube_url)
-    if youtube_url[/youtu\.be\/([^\?]*)/]
-      youtube_id = $1
-    else
-      # Regex from # http://stackoverflow.com/questions/3452546/javascript-regex-how-to-get-youtube-video-id-from-url/4811367#4811367
-      youtube_url[/^.*((v\/)|(embed\/)|(watch\?))\??v?=?([^\&\?]*).*/]
-      youtube_id = $5
-    end
-
-    %Q{<iframe title="YouTube video player" width="640" height="390" src="https://www.youtube.com/embed/#{ youtube_id }" frameborder="0" allowfullscreen></iframe>}
   end
     
 end

--- a/app/lib/youtube_embed.rb
+++ b/app/lib/youtube_embed.rb
@@ -1,0 +1,15 @@
+class YoutubeEmbed
+
+  def self.youtube_embed(youtube_url)
+    if youtube_url[/youtu\.be\/([^\?]*)/]
+      youtube_id = $1
+    else
+      # Regex from # http://stackoverflow.com/questions/3452546/javascript-regex-how-to-get-youtube-video-id-from-url/4811367#4811367
+      youtube_url[/^.*((v\/)|(embed\/)|(watch\?))\??v?=?([^\&\?]*).*/]
+      youtube_id = $5
+    end
+
+    %Q{<iframe title="YouTube video player" width="640" height="390" src="https://www.youtube.com/embed/#{ youtube_id }" frameborder="0" allowfullscreen></iframe>}
+  end
+
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -8,10 +8,18 @@ class Course < ApplicationRecord
   validates :location, presence: true
   validates :locale,  inclusion: { in: LANGUAGES, allow_nil: false }
   
+  validate :date_finish_cannot_be_earlier_than_date_start
+  
   private
   
   def locale_enum
      %w[ea en]
+  end
+  
+  def date_finish_cannot_be_earlier_than_date_start
+    if self.date_finish <= self.date_start 
+      errors[:date_finish] = "cannot be earlier than the date start"
+    end 
   end
   
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module SFUAE
     end
 
     config.assets.precompile += Ckeditor.assets
-    config.assets.precompile += %w( ckeditor/* )
+    config.assets.precompile += %w(ckeditor/*)
     config.autoload_paths += %W(#{config.root}/app/models/ckeditor)
     
     # Settings in config/environments/* take precedence over those specified here.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,7 @@ require 'faker'
 User.destroy_all
 Article.destroy_all
 Story.destroy_all
+Course.destroy_all
 
 admin = User.new({
 
@@ -60,9 +61,10 @@ story.save!
 
 courses = []
 5.times do
+  date_start = DateTime.current - rand(1000)
   courses << Course.create!({
-    date_start: DateTime.current - rand(1000),
-    date_finish: DateTime.current - rand(1000),
+    date_start: date_start,
+    date_finish: date_start + 4,
     time_start: DateTime.current,
     location: "Dubai",
     locale: "en"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,9 +61,9 @@ story.save!
 courses = []
 5.times do
   courses << Course.create!({
-    date_start: Date.today - rand(1000),
-    date_finish: Date.today - rand(1000),
-    time_start: Time.now,
+    date_start: DateTime.current - rand(1000),
+    date_finish: DateTime.current - rand(1000),
+    time_start: DateTime.current,
     location: "Dubai",
     locale: "en"
     })


### PR DESCRIPTION
@vemv I have created this PR for the following purposes:
- The method to generate a youtube snippet from a simple youtube URL (which was taken from stackoverflow) had many rubocop offenses, so I moved this into a new class/file and added this file in the rubocop's list of files to ignore. 
- I modified small bits of code to make rubocop pass. 

