### PR TITLE
Add locale on users creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,6 @@ group :staging, :development, :test do
   gem 'better_errors'
   gem 'factory_girl_rails'
   gem 'faker', '~> 1.7'
-  gem 'pry-byebug'
   gem 'pry-nav'
   gem 'pry-rails'
   gem 'pry-stack_explorer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,6 @@ GEM
       sass (>= 3.3.4)
     browser (2.3.0)
     builder (3.2.3)
-    byebug (9.0.6)
     capybara (2.14.0)
       addressable
       mime-types (>= 1.16)
@@ -270,9 +269,6 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.4.2)
-      byebug (~> 9.0)
-      pry (~> 0.10)
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
     pry-rails (0.3.6)
@@ -499,7 +495,6 @@ DEPENDENCIES
   paper_trail (~> 4)
   pg (~> 0.18)
   postmark
-  pry-byebug
   pry-nav
   pry-rails
   pry-stack_explorer

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,7 +52,7 @@ class ApplicationController < ActionController::Base
     if language
       locale = HttpAcceptLangParser.parse(language)
       logger.debug "* Locale set using accept_language to '#{locale}'"
-      locale.in?(User::LANGUAGES) ? locale : nil
+      locale.in?(User::LANGUAGES.map(&:to_sym)) ? locale : nil
     end 
   end
   

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,11 +46,13 @@ class ApplicationController < ActionController::Base
   end 
   
   private
+  
   def extract_locale_from_accept_language_header
-    if language = request.env['HTTP_ACCEPT_LANGUAGE']
-      locale = language.scan(/^[a-z]{2}/).first  # => => "en"
+    language = request.env['HTTP_ACCEPT_LANGUAGE'].presence
+    if language
+      locale = HttpAcceptLangParser.parse(language)
       logger.debug "* Locale set using accept_language to '#{locale}'"
-      locale
+      locale.in?(User::LANGUAGES) ? locale : nil
     end 
   end
   

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,11 +49,7 @@ class ApplicationController < ActionController::Base
   
   def extract_locale_from_accept_language_header
     language = request.env['HTTP_ACCEPT_LANGUAGE'].presence
-    if language
-      locale = HttpAcceptLangParser.parse(language)
-      logger.debug "* Locale set using accept_language to '#{locale}'"
-      locale.in?(User::LANGUAGES.map(&:to_sym)) ? locale : nil
-    end 
+    language ? HttpAcceptLangParser.parse(language) : nil
   end
   
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   skip_before_action :verify_authenticity_token
   
-  before_action :set_locale
+  around_action :set_locale
   
   include Pundit
   
@@ -27,7 +27,9 @@ class ApplicationController < ActionController::Base
   end
   
   def set_locale #  i18n
-    I18n.locale = params[:locale] || I18n.default_locale
+    I18n.locale = params[:locale] || current_user.try(:locale) || extract_locale_from_accept_language_header || I18n.default_locale
+    yield
+    I18n.locale = I18n.default_locale
   end
   
   def default_url_options
@@ -42,5 +44,14 @@ class ApplicationController < ActionController::Base
     end
     @user = User.new
   end 
+  
+  private
+  def extract_locale_from_accept_language_header
+    if language = request.env['HTTP_ACCEPT_LANGUAGE']
+      locale = language.scan(/^[a-z]{2}/).first  # => => "en"
+      logger.debug "* Locale set using accept_language to '#{locale}'"
+      locale
+    end 
+  end
   
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,7 +3,8 @@ class RegistrationsController < Devise::RegistrationsController
   private
 
   def sign_up_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation).merge(:locale => I18n.locale)
+    password = SecureRandom.hex(10)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation).merge(locale: I18n.locale, password: password, password_confirmation: password)
   end
 
   def account_update_params

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,8 +3,7 @@ class RegistrationsController < Devise::RegistrationsController
   private
 
   def sign_up_params
-    password = SecureRandom.hex(10)
-    params.require(:user).permit(:name, :email, :password, :password_confirmation).merge(locale: I18n.locale, password: password, password_confirmation: password)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation).merge(locale: I18n.locale)
   end
 
   def account_update_params

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,7 +3,7 @@ class RegistrationsController < Devise::RegistrationsController
   private
 
   def sign_up_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation).merge(:locale => I18n.locale)
   end
 
   def account_update_params

--- a/app/lib/http_accept_lang_parser.rb
+++ b/app/lib/http_accept_lang_parser.rb
@@ -1,7 +1,7 @@
 class HttpAcceptLangParser
   
   def self.parse(language)
-    language.scan(/^[a-z]{2}/).first  # => => "en"
+    language.scan(/^[a-z]{2}/).first.to_sym
   end
   
 end

--- a/app/lib/http_accept_lang_parser.rb
+++ b/app/lib/http_accept_lang_parser.rb
@@ -1,0 +1,7 @@
+class HttpAcceptLangParser
+  
+  def self.parse(language)
+    locale = language.scan(/^[a-z]{2}/).first  # => => "en"
+  end
+  
+end

--- a/app/lib/http_accept_lang_parser.rb
+++ b/app/lib/http_accept_lang_parser.rb
@@ -1,7 +1,9 @@
 class HttpAcceptLangParser
   
   def self.parse(language)
-    language.scan(/^[a-z]{2}/).first.to_sym
+    locale = language.scan(/^[a-z]{2}/).first.to_sym
+    Rails.logger.debug "* Locale set using accept_language to '#{locale}'"
+    locale.in?(User::LANGUAGES.map(&:to_sym)) ? locale : nil
   end
   
 end

--- a/app/lib/http_accept_lang_parser.rb
+++ b/app/lib/http_accept_lang_parser.rb
@@ -1,7 +1,7 @@
 class HttpAcceptLangParser
   
   def self.parse(language)
-    locale = language.scan(/^[a-z]{2}/).first  # => => "en"
+    language.scan(/^[a-z]{2}/).first  # => => "en"
   end
   
 end

--- a/app/lib/subscribe_to_newsletter_service.rb
+++ b/app/lib/subscribe_to_newsletter_service.rb
@@ -12,7 +12,7 @@ class SubscribeToNewsletterService
           status: "subscribed",
           merge_fields: {
             FNAME: @user.name,
-            LOCALE: "en"
+            LOCALE: @user.locale
           }
         }
       )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
 
   validates :email, email_format: { message: "doesn't look like an email address" }, presence: true
   validates :name, presence: true
-  validates :locale, inclusion: { in: LANGUAGES }
+  validates :locale, inclusion: LANGUAGES
 
   after_create :send_welcome_email
   after_create :subscribe_to_newsletter, if: :production_or_staging?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   private
   
   def password_required?
-    self.admin
+    super if self.admin
   end
 
   def send_welcome_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,10 @@ class User < ApplicationRecord
   after_create :subscribe_to_newsletter, if: :production_or_staging?
 
   private
+  
+  def password_required?
+    super if self.admin
+  end
 
   def send_welcome_email
     Users::Creation::UserMailer.welcome(self.id).deliver_now

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   private
   
   def password_required?
-    super if self.admin
+    self.admin
   end
 
   def send_welcome_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  LANGUAGES = %w[ar en].freeze
+  
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
@@ -6,6 +8,7 @@ class User < ApplicationRecord
 
   validates :email, email_format: { message: "doesn't look like an email address" }, presence: true
   validates :name, presence: true
+  validates :locale, inclusion: { in: LANGUAGES, allow_nil: false }
 
   after_create :send_welcome_email
   after_create :subscribe_to_newsletter, if: :production_or_staging?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
 
   validates :email, email_format: { message: "doesn't look like an email address" }, presence: true
   validates :name, presence: true
-  validates :locale, inclusion: { in: LANGUAGES, allow_nil: false }
+  validates :locale, inclusion: { in: LANGUAGES }
 
   after_create :send_welcome_email
   after_create :subscribe_to_newsletter, if: :production_or_staging?

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -6,7 +6,5 @@
       .form-inputs
         = f.input :name, required: true
         = f.input :email, required: true, autofocus: true
-        = f.hidden_field :password, value: '12345678'
-        = f.hidden_field :password_confirmation, value: '12345678'
       .form-actions
         = f.button :submit, "Sign up"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{lang: I18n.locale}
   %head
     - if test?
       :javascript

--- a/app/views/pages/_home.html.haml
+++ b/app/views/pages/_home.html.haml
@@ -7,7 +7,7 @@
     %p.normal.fadeInLeftBig.animated
       = t '.home_subtitle_1'
       %br
-      = t '.home_subtitle_2'
+      = t '.home_subtitle_2' 
     %p
       %a.btn.btn-lg.btn-default.btn-animated.scrollspy.margin-clear.smooth-scroll{:href => "#subscribe"}
         = t '.apply_now'
@@ -43,8 +43,6 @@
                   -# = flash[:notice]
                   = f.input :name, label: false, placeholder: I18n.t('views.shared.footer.name' ), required: true
                   = f.input :email, label: false, placeholder: I18n.t('views.shared.footer.email' ), required: true
-                  = f.hidden_field :password, value: '12345678'
-                  = f.hidden_field :password_confirmation, value: '12345678'
                   = f.button :submit, I18n.t('views.shared.footer.subscribe' ), class: "btn btn-lg btn-default.btn-animated margin-clear", id: "register"
                         
                                       

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -5,7 +5,7 @@ Devise.setup do |config|
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
   config.expire_all_remember_me_on_sign_out = true
   config.mailer_sender = "rakan@starfishproject.ae"
-  config.password_length = Rails.env.development? ? 1..72 : 10..255
+  config.password_length = Rails.env.development? ? 1..72 : 8..255
   config.reconfirmable = true
   config.remember_for = 6.weeks
   config.rememberable_options = {secure: false} # must be non-secure, else flash messages dissapear

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -5,7 +5,7 @@ Devise.setup do |config|
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
   config.expire_all_remember_me_on_sign_out = true
   config.mailer_sender = "rakan@starfishproject.ae"
-  config.password_length = Rails.env.development? ? 1..72 : 8..255
+  config.password_length = Rails.env.development? ? 1..72 : 10..255
   config.reconfirmable = true
   config.remember_for = 6.weeks
   config.rememberable_options = {secure: false} # must be non-secure, else flash messages dissapear

--- a/db/migrate/20170507110745_add_locale_to_users.rb
+++ b/db/migrate/20170507110745_add_locale_to_users.rb
@@ -1,0 +1,5 @@
+class AddLocaleToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :locale, :string, null: false, default: 'en'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170504204823) do
+ActiveRecord::Schema.define(version: 20170507110745) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema.define(version: 20170504204823) do
     t.datetime "updated_at",                             null: false
     t.string   "name"
     t.boolean  "admin",                  default: false, null: false
+    t.string   "locale",                 default: "en",  null: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -3,7 +3,6 @@ FactoryGirl.define do
   factory :user do
     
     email { "#{SecureRandom.hex(8)}@mailinator.com" } # mail can be actually checked at mailinator.com.
-    password { SecureRandom.hex }
     name { Faker::Name.first_name }
     
     transient do

--- a/spec/features/accept_language_spec.rb
+++ b/spec/features/accept_language_spec.rb
@@ -1,0 +1,9 @@
+describe "extract locale from client when user has a browser setup in en-US" do
+  
+  let(:accept_language){ "en-US,en;q=0.8,es-419;q=0.6,es;q=0.4,ca;q=0.2,af;q=0.2" }
+    
+  it "parses Accept-Language header into locale string en" do
+    expect(HttpAcceptLangParser.parse(accept_language)).to eq "en"
+  end
+      
+end

--- a/spec/features/accept_language_spec.rb
+++ b/spec/features/accept_language_spec.rb
@@ -1,9 +1,23 @@
-describe "extract locale from client when user has a browser setup in en-US" do
+describe "extract locale" do
   
-  let(:accept_language){ "en-US,en;q=0.8,es-419;q=0.6,es;q=0.4,ca;q=0.2,af;q=0.2" }
-    
-  it "parses Accept-Language header into locale string en" do
-    expect(HttpAcceptLangParser.parse(accept_language)).to eq "en"
-  end
+  context "when user has a browser setup in English" do
+  
+    let(:accept_language){ "en-US,en;q=0.8,es-419;q=0.6,es;q=0.4,ca;q=0.2,af;q=0.2" }
       
+    it "parses Accept-Language header into locale string en" do
+      expect(HttpAcceptLangParser.parse(accept_language)).to eq :en
+    end
+  
+  end
+  
+  context "when user has a browser setup in Arabic" do
+  
+    let(:accept_language){ "ar-sa,ar;q=0.3" }
+      
+    it "parses Accept-Language header into locale string ar" do
+      expect(HttpAcceptLangParser.parse(accept_language)).to eq :ar
+    end
+  
+  end
+    
 end

--- a/spec/features/locales_spec.rb
+++ b/spec/features/locales_spec.rb
@@ -5,7 +5,7 @@ describe 'Locale switching when landing page is in English' do
   }
     
   it 'changes to locale in Arabic when Arabic button is clicked' do
-    expect{ find("#change-to-arabic").click }.to change{ I18n.locale }.from(:en).to(:ar)
+    expect{ find("#change-to-arabic").click }.to change{ page.current_path }.from("/en").to("/ar")
     page_ok
   end
   

--- a/spec/features/locales_spec.rb
+++ b/spec/features/locales_spec.rb
@@ -5,8 +5,16 @@ describe 'Locale switching when landing page is in English' do
   }
     
   it 'changes to locale in Arabic when Arabic button is clicked' do
-    expect{ find("#change-to-arabic").click }.to change{ page.current_path }.from("/en").to("/ar")
+    expect{ 
+      find("#change-to-arabic").click 
+    }.to change { 
+      page.current_path 
+    }.from("/en").to("/ar").and change {
+      find('html')[:lang] 
+    }.from("en").to("ar")
+
     page_ok
+    
   end
   
 end

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -6,7 +6,7 @@ describe "User registration" do
     visit root_path
   }
   
-  it 'works' do
+  it 'results in a User being created' do
     
     find("#user_name").set reference.name
     find("#user_email").set reference.email

--- a/spec/features/user_registration_spec.rb
+++ b/spec/features/user_registration_spec.rb
@@ -1,0 +1,22 @@
+describe "User registration" do
+  
+  let(:reference){ FactoryGirl.build :user}
+  
+  before {
+    visit root_path
+  }
+  
+  it 'works' do
+    
+    find("#user_name").set reference.name
+    find("#user_email").set reference.email
+    
+    expect {
+      find("#register").click
+    }.to change {
+      User.count
+    }.by(1)
+    
+  end
+  
+end


### PR DESCRIPTION
@vemv I have added a `locale` string variable to `users`. In this way, the platform will know whether the user speaks Arabic or English, when the user is created. 